### PR TITLE
🔧  Gem Update のプルリクを自動作成させる

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
-name: Ruby
+name: CI
 
 on: [push, pull_request]
 
 jobs:
-  test:
+  ci:
     strategy:
       # いずれかのmatrixジョブが失敗した場合にGitHubは進行中のジョブをすべてキャンセルします
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+          mention: 'here'
+          if_mention: failure
         env:
           GITHUB_TOKEN: ${{ github.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/gem_update.yml
+++ b/.github/workflows/gem_update.yml
@@ -1,6 +1,10 @@
 name: GemUpdate
 
-on: [push]
+# https://docs.github.com/ja/actions/reference/events-that-trigger-workflows#scheduled-events
+# 毎月の１日の７時にgem update のプルリクを作成する
+on:
+  schedule:
+    - cron: '0 22 1 * *'
 
 jobs:
   create-gem-update:
@@ -23,6 +27,7 @@ jobs:
           git config --global user.name "dodonki1223"
       - name: Create gem update pull request
         # NOTE: hub コマンドがデフォルトで入っているようなのでそのまま使用する
+        #       https://github.com/github/hub#github-actions
         run: |
           git checkout -b gem_update
           bundle update

--- a/.github/workflows/gem_update.yml
+++ b/.github/workflows/gem_update.yml
@@ -1,6 +1,7 @@
 name: GemUpdate
 
 # https://docs.github.com/ja/actions/reference/events-that-trigger-workflows#scheduled-events
+# 注意：ベースブランチの直近のコミットでのみしか実行されない
 # 毎月の１日の７時にgem update のプルリクを作成する
 on:
   schedule:
@@ -34,7 +35,18 @@ jobs:
           git add .
           git commit -m ':wrench: Gem Update'
           git push origin gem_update
-          hub pull-request -m '🔧 Gem Update'
+          hub pull-request -b master -m '🔧 Gem Update'
         env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Github Actions notify to Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+          mention: 'here'
+          if_mention: failure
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always()
 

--- a/.github/workflows/gem_update.yml
+++ b/.github/workflows/gem_update.yml
@@ -1,0 +1,35 @@
+name: GemUpdate
+
+on: [push]
+
+jobs:
+  create-gem-update:
+    strategy:
+      # いずれかのmatrixジョブが失敗した場合にGitHubは進行中のジョブをすべてキャンセルします
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        # ref: https://github.com/ruby/setup-ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Install dependencies
+        run: bundle install
+      - name: Settings Git
+        run: |
+          git config --global user.email ${{ secrets.MAIL_ADDRESS }}
+          git config --global user.name "dodonki1223"
+      - name: Create gem update pull request
+        # NOTE: hub コマンドがデフォルトで入っているようなのでそのまま使用する
+        run: |
+          git checkout -b gem_update
+          bundle update
+          git add .
+          git commit -m ':wrench: Gem Update'
+          git push origin gem_update
+          hub pull-request -m '🔧 Gem Update'
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # qiita_command
 
+![CI](https://github.com/dodonki1223/qiita_command/workflows/CI/badge.svg?branch=master)
+
 Qiitaのトレンド情報（Daily, Weekly, Monthly）をコマンドで取得しコンソール上に表示することができます
 
 <img alt="00_sample" src="https://raw.githubusercontent.com/dodonki1223/image_garage/master/qiita_command/00_sample.gif" width="800px">


### PR DESCRIPTION
# 修正内容

- 毎月の１日の７時にgem update のプルリクを作成する
- GitHubActionsの通知を失敗時のみとする
- ReadmeにCIの結果を表示させる
- workflow の名前がわかりづらかったのでRename