### PR TITLE
🔧  gem update を毎月1日の9時にプルリクが作成されるようにする

### DIFF
--- a/.github/workflows/gem_update.yml
+++ b/.github/workflows/gem_update.yml
@@ -2,10 +2,10 @@ name: GemUpdate
 
 # https://docs.github.com/ja/actions/reference/events-that-trigger-workflows#scheduled-events
 # 注意：ベースブランチの直近のコミットでのみしか実行されない
-# 毎月の１日の７時にgem update のプルリクを作成する
+# 毎月の1日の9時にgem update のプルリクを作成する
 on:
   schedule:
-    - cron: '0 22 1 * *'
+    - cron: '0 0 1 * *'
 
 jobs:
   create-gem-update:


### PR DESCRIPTION
# 修正内容

- `0 22 1 * * ` の設定になっていたが、UTCだと2日の7時になってしまうため、意図したとおりの動きになっていなかったOrz
- 月末を取得するのが大変なため、シンプルに 9時にプルリクが作成されるように変更する

# その他

crontab の設定には以下のサイトがオススメ

- [Crontab.guru](https://crontab.guru/#0_0_31_*_*)
