### PR TITLE
🚨 Fix Rubocop RSpec/LeadingSubject

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,8 @@ Naming/MethodParameterName:
 # １行の長さのMAXを150文字とする
 Layout/LineLength:
   Max: 150
+  Exclude:
+    - 'Gemfile'
 
 # メソッドの行数をコメントを除いて５０行までとする
 Metrics/MethodLength:

--- a/spec/command_line_spec.rb
+++ b/spec/command_line_spec.rb
@@ -8,10 +8,10 @@ module QiitaCommands
   describe CLI do
     describe '#initialise' do
       shared_examples 'system shutdown' do
+        subject { described_class.new }
+
         include_context 'when set command line args'
         include_context 'when disable standard output'
-
-        subject { described_class.new }
 
         it { expect { subject }.to raise_error(SystemExit) }
       end

--- a/spec/trend_spec.rb
+++ b/spec/trend_spec.rb
@@ -7,8 +7,9 @@ require './qiita_commands/trend'
 module QiitaCommands
   describe Trend do
     describe '#initialize' do
-      include_context 'when disable standard output'
       subject(:instance) { described_class.new(type) }
+
+      include_context 'when disable standard output'
 
       let(:type) { QiitaTrend::TrendType::WEEKLY }
 


### PR DESCRIPTION
# 修正内容

- Rubocopのバージョンアップによる RSpec/LeadingSubject の対応
    - RSpecのsubject を一番上に持っていく
- Rubocopが Layout/LineLength で Gemfileを対象にしたので 除外設定に変更